### PR TITLE
Add Cognito login and logout flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,23 @@ For more information about text-to-speech using the OpenAI API, check out our [d
 
    This step is not needed to run the application and only affects the sharing feature.
 
-6. **Run the app:**
+6. **Configure Amazon Cognito:**
+
+   The application uses Amazon Cognito for authentication. Copy `.env.example`
+   to `.env` and fill in your user pool details:
+
+   ```bash
+   NEXT_PUBLIC_COGNITO_USER_POOL_ID=<YOUR_USER_POOL_ID>
+   NEXT_PUBLIC_COGNITO_CLIENT_ID=<YOUR_CLIENT_ID>
+   NEXT_PUBLIC_COGNITO_REGION=<YOUR_AWS_REGION>
+   NEXT_PUBLIC_COGNITO_DOMAIN=<YOUR_COGNITO_DOMAIN>
+   ```
+
+   Ensure your app client allows `http://localhost:3000/callback` as a callback
+   URL and `http://localhost:3000/signout` as a logout URL and includes the
+   `openid` and `email` scopes.
+
+7. **Run the app:**
 
    ```bash
    npm run dev

--- a/src/app/signout/page.tsx
+++ b/src/app/signout/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "react-oidc-context";
+
+export default function SignOutPage() {
+  const auth = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    auth
+      .signoutRedirectCallback()
+      .catch(() => {})
+      .finally(() => {
+        router.replace("/login");
+      });
+  }, [auth, router]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      Signing you out...
+    </div>
+  );
+}

--- a/src/components/OIDCProvider.tsx
+++ b/src/components/OIDCProvider.tsx
@@ -5,12 +5,12 @@ import { ReactNode } from "react";
 
 const oidcConfig = {
   authority:
-    `https://cognito-idp.${process.env.NEXT_PUBLIC_COGNITO_REGION}.amazonaws.com/${process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID}`,
-  client_id: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID!,
-  redirect_uri:
-    (typeof window !== "undefined" ? window.location.origin : "") + "/callback",
+    "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_2fafEaDIB",
+  client_id: "1rdijil48c7vq90gjofs9r9n74",
+  redirect_uri: "http://localhost:3000/callback",
   response_type: "code",
-  scope: "openid email phone",
+  scope: "email openid phone",
+  post_logout_redirect_uri: "http://localhost:3000/signout",
 };
 
 export function OIDCProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- configure `OIDCProvider` with a logout redirect
- add `/signout` route to process Cognito logout callbacks
- document Cognito setup instructions in README
- use static Cognito values in the OIDC configuration

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e20f396c0833188ee39d2539af66a