### PR TITLE
Add automatic Cognito login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,30 @@ For more information about text-to-speech using the OpenAI API, check out our [d
 
    This step is not needed to run the application and only affects the sharing feature.
 
-6. **Run the app:**
+6. **Configure Amazon Cognito:**
+
+   The application uses Amazon Cognito for authentication. Copy `.env.example`
+   to `.env` and fill in your user pool details:
+
+   ```bash
+   NEXT_PUBLIC_COGNITO_USER_POOL_ID=<YOUR_USER_POOL_ID>
+   NEXT_PUBLIC_COGNITO_CLIENT_ID=<YOUR_CLIENT_ID>
+   NEXT_PUBLIC_COGNITO_REGION=<YOUR_AWS_REGION>
+   NEXT_PUBLIC_COGNITO_DOMAIN=<YOUR_COGNITO_DOMAIN>
+   ```
+
+   Ensure your app client allows `http://localhost:3000/callback` as a callback
+   URL and `http://localhost:3000/signout` as a logout URL and includes the
+   `openid` and `email` scopes.
+
+7. **Run the app:**
 
    ```bash
    npm run dev
    ```
 
    The app will be available at [`http://localhost:3000`](http://localhost:3000).
+   Visit [`/login`](http://localhost:3000/login) to sign in with Cognito.
 
 > [!NOTE]  
 > Be aware that if you deploy this app to a public server, you are responsible for any usage it may incur using your OpenAI API key.

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { signIn } from '@/lib/auth';
-
-
+import { useEffect } from "react";
 import { useAuth } from "react-oidc-context";
 
 export default function LoginPage() {
   const auth = useAuth();
+
+  useEffect(() => {
+    if (!auth.isLoading && !auth.isAuthenticated && !auth.error) {
+      auth.signinRedirect().catch(() => {});
+    }
+  }, [auth]);
 
   if (auth.isLoading) {
     return <div className="min-h-screen flex items-center justify-center">Loading...</div>;
@@ -40,12 +42,7 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-custom-gray">
-      <button
-        onClick={() => auth.signinRedirect()}
-        className="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded-md transition"
-      >
-        Sign in
-      </button>
+      Redirecting to sign in...
     </div>
   );
 }

--- a/src/app/signout/page.tsx
+++ b/src/app/signout/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "react-oidc-context";
+
+export default function SignOutPage() {
+  const auth = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    auth
+      .signoutRedirectCallback()
+      .catch(() => {})
+      .finally(() => {
+        router.replace("/login");
+      });
+  }, [auth, router]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      Signing you out...
+    </div>
+  );
+}

--- a/src/components/OIDCProvider.tsx
+++ b/src/components/OIDCProvider.tsx
@@ -3,12 +3,14 @@
 import { AuthProvider } from "react-oidc-context";
 import { ReactNode } from "react";
 
+const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
+
 const oidcConfig = {
   authority:
     `https://cognito-idp.${process.env.NEXT_PUBLIC_COGNITO_REGION}.amazonaws.com/${process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID}`,
   client_id: process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID!,
-  redirect_uri:
-    (typeof window !== "undefined" ? window.location.origin : "") + "/callback",
+  redirect_uri: baseUrl + "/callback",
+  post_logout_redirect_uri: baseUrl + "/signout",
   response_type: "code",
   scope: "openid email phone",
 };


### PR DESCRIPTION
## Summary
- automatically redirect from the login page to the Cognito hosted UI
- restore environment variable based OIDC configuration
- point README users to `/login` when running the app

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684e20f396c0833188ee39d2539af66a